### PR TITLE
Implement EquatableCellModelDataSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "jflinter/Dwifft" ~> 0.8

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "jflinter/Dwifft" "0.8"

--- a/CellKit.podspec
+++ b/CellKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "CellKit"
   s.version      = "0.1"
-  s.summary      = ""
+  s.summary      = "Table View and Collection View data source wrapper"
   s.description  = <<-DESC
     Your description here.
   DESC
@@ -13,7 +13,18 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
-  s.source       = { :git => "https://github.com/thefuntasty/CellKit.git", :tag => s.version.to_s }
-  s.source_files  = "Sources/**/*"
+  s.source       = { :git => "https://github.com/thefuntasty/CellKit.git", :tag => s.version.to_s }  
   s.frameworks  = "Foundation"
+
+  s.subspec 'Core' do |core|
+    core.source_files  = "Sources/*"
+  end
+
+  s.subspec 'Equatable' do |equatable|
+    equatable.dependency 'CellKit/Core'    
+    equatable.source_files = 'Sources/EquatableDataSource/*'
+    equatable.dependency 'Dwifft', '~> 0.8'
+  end
+
+  s.default_subspec = 'Core'  
 end

--- a/CellKit.xcodeproj/project.pbxproj
+++ b/CellKit.xcodeproj/project.pbxproj
@@ -18,31 +18,29 @@
 		D02135B120CA609F00EE79D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D02135AF20CA609F00EE79D1 /* LaunchScreen.storyboard */; };
 		D02135B720CA6E6D00EE79D1 /* CellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135B620CA6E6D00EE79D1 /* CellModel.swift */; };
 		D02135B820CA6E7100EE79D1 /* CellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135B620CA6E6D00EE79D1 /* CellModel.swift */; };
-		D02135B920CA6E7100EE79D1 /* CellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135B620CA6E6D00EE79D1 /* CellModel.swift */; };
 		D02135BA20CA6E7100EE79D1 /* CellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135B620CA6E6D00EE79D1 /* CellModel.swift */; };
 		D02135BC20CA6EA600EE79D1 /* CellConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */; };
 		D02135BD20CA6EAA00EE79D1 /* CellConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */; };
-		D02135BE20CA6EAA00EE79D1 /* CellConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */; };
 		D02135BF20CA6EAA00EE79D1 /* CellConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */; };
 		D02135C120CA6EDE00EE79D1 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
 		D02135C320CA6FEE00EE79D1 /* CellModelSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */; };
 		D02135C520CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
 		D02135C620CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
-		D02135C720CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
 		D02135C820CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
 		D082B7CA20CA985100B5E7C8 /* DeviceiOSCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7C920CA985100B5E7C8 /* DeviceiOSCellModel.swift */; };
 		D082B7CD20CA9F9400B5E7C8 /* DeviceiOSCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CC20CA9F9400B5E7C8 /* DeviceiOSCell.swift */; };
 		D082B7D020CACA8100B5E7C8 /* EquatableCellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */; };
-		D082B7D120CACA8200B5E7C8 /* EquatableCellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */; };
 		D082B7D220CACA8200B5E7C8 /* EquatableCellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */; };
 		D082B7D320CACA8300B5E7C8 /* EquatableCellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */; };
 		D082B7E720D3A73B00B5E7C8 /* CellModelSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */; };
-		D082B7E820D3A73C00B5E7C8 /* CellModelSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */; };
 		D082B7E920D3A73C00B5E7C8 /* CellModelSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */; };
 		D082B7EA20D3A75200B5E7C8 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
 		D082B7EB20D3A75300B5E7C8 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
-		D082B7EC20D3A75400B5E7C8 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
 		D095541920DD335900BA32F9 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D095541820DD335900BA32F9 /* DataSource.swift */; };
+		D095541E20DFDDE100BA32F9 /* Dwifft.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D095541D20DFDDE100BA32F9 /* Dwifft.framework */; };
+		D095542020DFDDF400BA32F9 /* Dwifft_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D095541F20DFDDF400BA32F9 /* Dwifft_tvOS.framework */; };
+		D095542620DFE96900BA32F9 /* Dwifft.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D095542520DFE96800BA32F9 /* Dwifft.framework */; };
+		D095542720DFE96900BA32F9 /* Dwifft.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D095542520DFE96800BA32F9 /* Dwifft.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DD7502881C68FEDE006590AF /* CellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* CellKit.framework */; };
 		DD7502921C690C7A006590AF /* CellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* CellKit.framework */; };
 		E7BF419E20D7BC5700187490 /* CellConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BF419D20D7BC5700187490 /* CellConfigurable.swift */; };
@@ -79,10 +77,23 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		D095542820DFE96900BA32F9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D095542720DFE96900BA32F9 /* Dwifft.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		52D6D97C1BEFF229002C0205 /* CellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9861BEFF229002C0205 /* CellKit-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		52D6D9E21BEFFF6E002C0205 /* CellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9F01BEFFFBE002C0205 /* CellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6DA0F1BF000BD002C0205 /* CellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8933C7891EB5B82A000D00A4 /* CellKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellKitTests.swift; sourceTree = "<group>"; };
@@ -104,6 +115,10 @@
 		D082B7CC20CA9F9400B5E7C8 /* DeviceiOSCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceiOSCell.swift; sourceTree = "<group>"; };
 		D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableCellModelDataSource.swift; sourceTree = "<group>"; };
 		D095541820DD335900BA32F9 /* DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		D095541A20DFDA7F00BA32F9 /* Dwifft.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dwifft.framework; path = Carthage/Build/iOS/Dwifft.framework; sourceTree = "<group>"; };
+		D095541D20DFDDE100BA32F9 /* Dwifft.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dwifft.framework; path = Carthage/Build/Mac/Dwifft.framework; sourceTree = "<group>"; };
+		D095541F20DFDDF400BA32F9 /* Dwifft_tvOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dwifft_tvOS.framework; path = Carthage/Build/tvOS/Dwifft_tvOS.framework; sourceTree = "<group>"; };
+		D095542520DFE96800BA32F9 /* Dwifft.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dwifft.framework; path = Carthage/Build/iOS/Dwifft.framework; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* CellKit-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75028D1C690C7A006590AF /* CellKit-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7BF419D20D7BC5700187490 /* CellConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurable.swift; sourceTree = "<group>"; };
@@ -125,17 +140,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		52D6D9DE1BEFFF6E002C0205 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		52D6D9EC1BEFFFBE002C0205 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D095542020DFDDF400BA32F9 /* Dwifft_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -143,6 +152,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D095541E20DFDDE100BA32F9 /* Dwifft.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,6 +160,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D095542620DFE96900BA32F9 /* Dwifft.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -175,6 +186,7 @@
 		52D6D9721BEFF229002C0205 = {
 			isa = PBXGroup;
 			children = (
+				D095542520DFE96800BA32F9 /* Dwifft.framework */,
 				8933C7811EB5B7E0000D00A4 /* Sources */,
 				8933C7831EB5B7EB000D00A4 /* Tests */,
 				52D6D99C1BEFF38C002C0205 /* Configs */,
@@ -189,7 +201,6 @@
 			children = (
 				52D6D97C1BEFF229002C0205 /* CellKit.framework */,
 				52D6D9861BEFF229002C0205 /* CellKit-iOS Tests.xctest */,
-				52D6D9E21BEFFF6E002C0205 /* CellKit.framework */,
 				52D6D9F01BEFFFBE002C0205 /* CellKit.framework */,
 				52D6DA0F1BF000BD002C0205 /* CellKit.framework */,
 				DD75027A1C68FCFC006590AF /* CellKit-macOS Tests.xctest */,
@@ -211,13 +222,13 @@
 		8933C7811EB5B7E0000D00A4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				D095542120DFE7BF00BA32F9 /* EquatableDataSource */,
 				D02135B620CA6E6D00EE79D1 /* CellModel.swift */,
 				D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */,
 				E7BF419D20D7BC5700187490 /* CellConfigurable.swift */,
 				D095541820DD335900BA32F9 /* DataSource.swift */,
 				D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */,
 				D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */,
-				D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */,
 				D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */,
 			);
 			path = Sources;
@@ -249,6 +260,9 @@
 		D02135CB20CA7ABF00EE79D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D095541F20DFDDF400BA32F9 /* Dwifft_tvOS.framework */,
+				D095541D20DFDDE100BA32F9 /* Dwifft.framework */,
+				D095541A20DFDA7F00BA32F9 /* Dwifft.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -260,6 +274,14 @@
 				D082B7C920CA985100B5E7C8 /* DeviceiOSCellModel.swift */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		D095542120DFE7BF00BA32F9 /* EquatableDataSource */ = {
+			isa = PBXGroup;
+			children = (
+				D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */,
+			);
+			path = EquatableDataSource;
 			sourceTree = "<group>";
 		};
 		DD7502721C68FC1B006590AF /* Frameworks */ = {
@@ -282,13 +304,6 @@
 
 /* Begin PBXHeadersBuildPhase section */
 		52D6D9791BEFF229002C0205 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		52D6D9DF1BEFFF6E002C0205 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -348,24 +363,6 @@
 			productReference = 52D6D9861BEFF229002C0205 /* CellKit-iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		52D6D9E11BEFFF6E002C0205 /* CellKit-watchOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 52D6D9E71BEFFF6E002C0205 /* Build configuration list for PBXNativeTarget "CellKit-watchOS" */;
-			buildPhases = (
-				52D6D9DD1BEFFF6E002C0205 /* Sources */,
-				52D6D9DE1BEFFF6E002C0205 /* Frameworks */,
-				52D6D9DF1BEFFF6E002C0205 /* Headers */,
-				52D6D9E01BEFFF6E002C0205 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "CellKit-watchOS";
-			productName = "CellKit-watchOS";
-			productReference = 52D6D9E21BEFFF6E002C0205 /* CellKit.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		52D6D9EF1BEFFFBE002C0205 /* CellKit-tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 52D6DA011BEFFFBE002C0205 /* Build configuration list for PBXNativeTarget "CellKit-tvOS" */;
@@ -409,6 +406,7 @@
 				D02135A020CA609D00EE79D1 /* Sources */,
 				D02135A120CA609D00EE79D1 /* Frameworks */,
 				D02135A220CA609D00EE79D1 /* Resources */,
+				D095542820DFE96900BA32F9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -474,10 +472,6 @@
 						CreatedOnToolsVersion = 7.1;
 						LastSwiftMigration = 0800;
 					};
-					52D6D9E11BEFFF6E002C0205 = {
-						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
-					};
 					52D6D9EF1BEFFFBE002C0205 = {
 						CreatedOnToolsVersion = 7.1;
 						LastSwiftMigration = 0800;
@@ -516,7 +510,6 @@
 			targets = (
 				52D6D97B1BEFF229002C0205 /* CellKit-iOS */,
 				52D6DA0E1BF000BD002C0205 /* CellKit-macOS */,
-				52D6D9E11BEFFF6E002C0205 /* CellKit-watchOS */,
 				52D6D9EF1BEFFFBE002C0205 /* CellKit-tvOS */,
 				52D6D9851BEFF229002C0205 /* CellKit-iOS Tests */,
 				DD7502791C68FCFC006590AF /* CellKit-macOS Tests */,
@@ -535,13 +528,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		52D6D9841BEFF229002C0205 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		52D6D9E01BEFFF6E002C0205 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -599,6 +585,7 @@
 				D02135C120CA6EDE00EE79D1 /* CellModelDataSource.swift in Sources */,
 				D02135C520CA742B00EE79D1 /* CellModelSelectable.swift in Sources */,
 				D02135B720CA6E6D00EE79D1 /* CellModel.swift in Sources */,
+				D095541920DD335900BA32F9 /* DataSource.swift in Sources */,
 				D02135C320CA6FEE00EE79D1 /* CellModelSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -608,19 +595,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8933C7901EB5B82D000D00A4 /* CellKitTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		52D6D9DD1BEFFF6E002C0205 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D02135C720CA742B00EE79D1 /* CellModelSelectable.swift in Sources */,
-				D082B7D120CACA8200B5E7C8 /* EquatableCellModelDataSource.swift in Sources */,
-				D082B7E820D3A73C00B5E7C8 /* CellModelSection.swift in Sources */,
-				D02135BE20CA6EAA00EE79D1 /* CellConvertible.swift in Sources */,
-				D082B7EC20D3A75400B5E7C8 /* CellModelDataSource.swift in Sources */,
-				D02135B920CA6E7100EE79D1 /* CellModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -843,6 +817,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Configs/CellKit.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -866,6 +844,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Configs/CellKit.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -904,51 +886,6 @@
 			};
 			name = Release;
 		};
-		52D6D9E81BEFFF6E002C0205 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Configs/CellKit.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.thefuntasty.CellKit.CellKit-watchOS";
-				PRODUCT_NAME = CellKit;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
-		52D6D9E91BEFFF6E002C0205 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Configs/CellKit.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.thefuntasty.CellKit.CellKit-watchOS";
-				PRODUCT_NAME = CellKit;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
 		52D6DA021BEFFFBE002C0205 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -958,6 +895,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Configs/CellKit.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -980,6 +921,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Configs/CellKit.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1004,6 +949,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Configs/CellKit.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1027,6 +976,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Configs/CellKit.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1056,6 +1009,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5VWB99DS38;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
@@ -1083,6 +1040,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5VWB99DS38;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
@@ -1179,15 +1140,6 @@
 			buildConfigurations = (
 				52D6D9941BEFF229002C0205 /* Debug */,
 				52D6D9951BEFF229002C0205 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		52D6D9E71BEFFF6E002C0205 /* Build configuration list for PBXNativeTarget "CellKit-watchOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				52D6D9E81BEFFF6E002C0205 /* Debug */,
-				52D6D9E91BEFFF6E002C0205 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CellKit.xcodeproj/project.pbxproj
+++ b/CellKit.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		D082B7EA20D3A75200B5E7C8 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
 		D082B7EB20D3A75300B5E7C8 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
 		D082B7EC20D3A75400B5E7C8 /* CellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */; };
+		D095541920DD335900BA32F9 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D095541820DD335900BA32F9 /* DataSource.swift */; };
 		DD7502881C68FEDE006590AF /* CellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* CellKit.framework */; };
 		DD7502921C690C7A006590AF /* CellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* CellKit.framework */; };
 		E7BF419E20D7BC5700187490 /* CellConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BF419D20D7BC5700187490 /* CellConfigurable.swift */; };
@@ -102,6 +103,7 @@
 		D082B7C920CA985100B5E7C8 /* DeviceiOSCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceiOSCellModel.swift; sourceTree = "<group>"; };
 		D082B7CC20CA9F9400B5E7C8 /* DeviceiOSCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceiOSCell.swift; sourceTree = "<group>"; };
 		D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableCellModelDataSource.swift; sourceTree = "<group>"; };
+		D095541820DD335900BA32F9 /* DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* CellKit-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75028D1C690C7A006590AF /* CellKit-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7BF419D20D7BC5700187490 /* CellConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurable.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				D02135B620CA6E6D00EE79D1 /* CellModel.swift */,
 				D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */,
 				E7BF419D20D7BC5700187490 /* CellConfigurable.swift */,
+				D095541820DD335900BA32F9 /* DataSource.swift */,
 				D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */,
 				D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */,
 				D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */,
@@ -460,7 +463,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "FUNTASTY Digital, s.r.o.";
 				TargetAttributes = {
 					52D6D97B1BEFF229002C0205 = {
@@ -731,12 +734,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -788,12 +793,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;

--- a/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-iOS.xcscheme
+++ b/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-macOS.xcscheme
+++ b/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-tvOS.xcscheme
+++ b/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-watchOS.xcscheme
+++ b/CellKit.xcodeproj/xcshareddata/xcschemes/CellKit-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>
@@ -38,7 +37,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -78,9 +78,9 @@
                                     <action selector="didTapAddRowA" destination="BYZ-38-t0r" id="8t7-e3-4dh"/>
                                 </connections>
                             </barButtonItem>
-                            <barButtonItem title="+Section" id="ih0-d8-ZNp">
+                            <barButtonItem title="Reset" id="ih0-d8-ZNp">
                                 <connections>
-                                    <action selector="didTapAddSection" destination="BYZ-38-t0r" id="7i8-0O-HKN"/>
+                                    <action selector="didTapReset" destination="BYZ-38-t0r" id="ieK-z4-cV2"/>
                                 </connections>
                             </barButtonItem>
                         </rightBarButtonItems>

--- a/Example/Cells/DeviceiOSCellModel.swift
+++ b/Example/Cells/DeviceiOSCellModel.swift
@@ -13,7 +13,7 @@ struct DeviceiOSCellModel: Equatable {
     let name: String
 }
 
-extension DeviceiOSCellModel: CellConvertible {
+extension DeviceiOSCellModel: CellConvertible, EquatableCellModel {
     typealias Cell = DeviceiOSCell
 
     var cellHeight: CGFloat {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -11,30 +11,34 @@ import CellKit
 
 class ViewController: UIViewController {
 
-    @IBOutlet var tableView: UITableView!
-    var dataSource: EquatableCellModelDataSource!
+    @IBOutlet private var tableView: UITableView!
+    private var dataSource: EquatableCellModelDataSource!
 
-    var phones = ["iPhone", "iPhone 3G", "iPhone 3GS", "iPhone 4", "iPhone 4S", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6s", "iPhone SE", "iPhone 7", "iPhone 8", "iPhone X"]
+    private var phones = ["iPhone", "iPhone 3G", "iPhone 3GS", "iPhone 4", "iPhone 4S", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6s", "iPhone SE", "iPhone 7", "iPhone 8", "iPhone X"]
+
+    private var phonesSection: EquatableCellModelSection {
+        let cellModels = phones.map { DeviceiOSCellModel(name: $0) }
+        return EquatableCellModelSection(cells: cellModels, identifier: "Section 1")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let cellModels = phones.map { DeviceiOSCellModel(name: $0) }
-        let section = EquatableCellModelSection(cells: cellModels, identifier: "Section 1")
-        dataSource = EquatableCellModelDataSource(tableView, sections: [section])
+        dataSource = EquatableCellModelDataSource(tableView, sections: [phonesSection])
         dataSource.delegate = self
         tableView.dataSource = dataSource
         tableView.delegate = dataSource
     }
 
-    @IBAction func didTapAddSection() {
-        
+    @IBAction func didTapReset() {
+        dataSource?.sections = [phonesSection]
     }
 
     @IBAction func didTapAddRowA() {
         if let section = dataSource?.sections[0] {
             var section = section
-            section.cells.insert(DeviceiOSCellModel(name: "iPhone X \(arc4random() % 100)"), at: 0)
+            let phoneName = "iPhone \(arc4random() % 100)"
+            section.cells.insert(DeviceiOSCellModel(name: phoneName), at: 0)
             dataSource?.sections = [section]
         }
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -12,7 +12,7 @@ import CellKit
 class ViewController: UIViewController {
 
     @IBOutlet var tableView: UITableView!
-    var dataSource: CellModelDataSource? = nil
+    var dataSource: EquatableCellModelDataSource!
 
     var phones = ["iPhone", "iPhone 3G", "iPhone 3GS", "iPhone 4", "iPhone 4S", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6s", "iPhone SE", "iPhone 7", "iPhone 8", "iPhone X"]
 
@@ -20,7 +20,9 @@ class ViewController: UIViewController {
         super.viewDidLoad()
 
         let cellModels = phones.map { DeviceiOSCellModel(name: $0) }
-        dataSource = CellModelDataSource([CellModelSection(cells: cellModels)])
+        let section = EquatableCellModelSection(cells: cellModels, identifier: "Section 1")
+        dataSource = EquatableCellModelDataSource(tableView, sections: [section])
+        dataSource.delegate = self
         tableView.dataSource = dataSource
         tableView.delegate = dataSource
     }
@@ -30,8 +32,11 @@ class ViewController: UIViewController {
     }
 
     @IBAction func didTapAddRowA() {
-        var section = dataSource?.sections.first
-        
+        if let section = dataSource?.sections[0] {
+            var section = section
+            section.cells.insert(DeviceiOSCellModel(name: "iPhone X \(arc4random() % 100)"), at: 0)
+            dataSource?.sections = [section]
+        }
     }
 
     @IBAction func didTapAddRowB() {
@@ -39,3 +44,12 @@ class ViewController: UIViewController {
     }
 }
 
+extension ViewController: CellModelDataSourceDelegate {
+    func didSelectCellModel(_ cellModel: CellModel, at indexPath: IndexPath) {
+        if let section = dataSource?.sections[indexPath.section] {
+            var section = section
+            section.cells.remove(at: indexPath.row)
+            dataSource?.sections = [section]
+        }
+    }
+}

--- a/Sources/CellModel.swift
+++ b/Sources/CellModel.swift
@@ -30,8 +30,8 @@ extension EquatableCellModel where Self: Equatable {
     }
 
     public func isEqualTo(_ other: CellModel) -> Bool {
-        guard let otherFruit = other as? Self else { return false }
-        return self == otherFruit
+        guard let otherCellModel = other as? Self else { return false }
+        return self == otherCellModel
     }
 }
 
@@ -58,8 +58,7 @@ public protocol SupplementaryViewModel: CellModel {
 }
 
 public struct AnyEquatableCellModel: EquatableCellModel {
-
-    private let cellModel: CellModel
+    public var cellModel: EquatableCellModel
 
     public var reuseIdentifier: String {
         return cellModel.reuseIdentifier
@@ -78,7 +77,7 @@ public struct AnyEquatableCellModel: EquatableCellModel {
         return cellModel.hashableElement
     }
 
-    init(_ cellModel: CellModel) {
+    init(_ cellModel: EquatableCellModel) {
         self.cellModel = cellModel
     }
 
@@ -89,6 +88,6 @@ public struct AnyEquatableCellModel: EquatableCellModel {
 
 extension AnyEquatableCellModel: Equatable {
     public static func ==(lhs: AnyEquatableCellModel, rhs: AnyEquatableCellModel) -> Bool {
-        return lhs.isEqualTo(rhs)
+        return lhs.cellModel.isEqualTo(rhs.cellModel)
     }
 }

--- a/Sources/CellModelDataSource.swift
+++ b/Sources/CellModelDataSource.swift
@@ -12,7 +12,7 @@ public protocol CellModelDataSourceDelegate: class {
     func didSelectCellModel(_ cellModel: CellModel, at indexPath: IndexPath)
 }
 
-public class CellModelDataSource: AbstractDataSource, DataSource {
+open class CellModelDataSource: AbstractDataSource, DataSource {
 
     public var sections: [CellModelSection]
 
@@ -28,23 +28,23 @@ public class CellModelDataSource: AbstractDataSource, DataSource {
         return sections[index]
     }
 
-    public override func numberOfSections() -> Int {
+    override func numberOfSections() -> Int {
         return sections.count
     }
 
-    public override func cellModels(in section: Int) -> [CellModel] {
+    override func cellModels(in section: Int) -> [CellModel] {
         return sections[section].cells
     }
 
-    public override func header(in section: Int) -> SupplementaryViewModel? {
+    override func header(in section: Int) -> SupplementaryViewModel? {
         return sections[section].headerView
     }
 
-    public override func footer(in section: Int) -> SupplementaryViewModel? {
+    override func footer(in section: Int) -> SupplementaryViewModel? {
         return sections[section].footerView
     }
 
-    public override func cellModel(at indexPath: IndexPath) -> CellModel {
+    override func cellModel(at indexPath: IndexPath) -> CellModel {
         return sections[indexPath.section].cells[indexPath.row]
     }
 }

--- a/Sources/CellModelDataSource.swift
+++ b/Sources/CellModelDataSource.swift
@@ -28,7 +28,7 @@ public class CellModelDataSource: AbstractDataSource, DataSource {
         return sections[index]
     }
 
-    public override func sectionsCount() -> Int {
+    public override func numberOfSections() -> Int {
         return sections.count
     }
 

--- a/Sources/CellModelDataSource.swift
+++ b/Sources/CellModelDataSource.swift
@@ -12,11 +12,9 @@ public protocol CellModelDataSourceDelegate: class {
     func didSelectCellModel(_ cellModel: CellModel, at indexPath: IndexPath)
 }
 
-public class CellModelDataSource: NSObject {
+public class CellModelDataSource: AbstractDataSource, DataSource {
 
     public var sections: [CellModelSection]
-
-    public weak var delegate: CellModelDataSourceDelegate?
 
     public var first: CellModelSection? {
         return sections.first
@@ -26,89 +24,27 @@ public class CellModelDataSource: NSObject {
         self.sections = sections
     }
 
-    subscript(index: Int) -> CellModelSection {
+    public subscript(index: Int) -> CellModelSection {
         return sections[index]
     }
-}
 
-extension CellModelDataSource: UITableViewDataSource {
-    public func numberOfSections(in tableView: UITableView) -> Int {
+    public override func sectionsCount() -> Int {
         return sections.count
     }
 
-    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return sections[section].cells.count
+    public override func cellModels(in section: Int) -> [CellModel] {
+        return sections[section].cells
     }
 
-    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let item = sections[indexPath.section].cells[indexPath.row]
-        let cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier, for: indexPath)
-        item.configure(cell: cell)
-        return cell
+    public override func header(in section: Int) -> SupplementaryViewModel? {
+        return sections[section].headerView
     }
 
-    public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        return sections[indexPath.section].cells[indexPath.row].highlighting
+    public override func footer(in section: Int) -> SupplementaryViewModel? {
+        return sections[section].footerView
     }
 
-    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if let item = sections[section].headerView, let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: item.reuseIdentifier) {
-            item.configure(cell: header)
-            return header
-        }
-        return nil
-    }
-
-    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return sections[section].headerView?.height ?? CGFloat.leastNonzeroMagnitude
-    }
-
-    public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if let item = sections[section].footerView, let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: item.reuseIdentifier) {
-            item.configure(cell: footer)
-            return footer
-        }
-        return nil
-    }
-
-    public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return sections[section].footerView?.height ?? CGFloat.leastNonzeroMagnitude
-    }
-}
-
-extension CellModelDataSource: UITableViewDelegate {
-    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return sections[indexPath.section].cells[indexPath.row].cellHeight
-    }
-
-    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if let cellModel = sections[indexPath.section].cells[indexPath.row] as? CellModelSelectable {
-            cellModel.didSelect()
-        } else {
-            delegate?.didSelectCellModel(sections[indexPath.section].cells[indexPath.row], at: indexPath)
-        }
-    }
-}
-
-extension CellModelDataSource: UICollectionViewDataSource {
-    public func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return sections.count
-    }
-
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return sections[section].cells.count
-    }
-
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let item = sections[indexPath.section].cells[indexPath.row]
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: item.reuseIdentifier, for: indexPath)
-        item.configure(cell: cell)
-        return cell
-    }
-}
-
-extension CellModelDataSource: UICollectionViewDelegate {
-    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        delegate?.didSelectCellModel(sections[indexPath.section].cells[indexPath.row], at: indexPath)
+    public override func cellModel(at indexPath: IndexPath) -> CellModel {
+        return sections[indexPath.section].cells[indexPath.row]
     }
 }

--- a/Sources/CellModelSection.swift
+++ b/Sources/CellModelSection.swift
@@ -8,27 +8,35 @@
 
 import Foundation
 
-public class CellModelSection: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = CellModel
+public typealias CellModelSection = GenericCellModelSection<CellModel>
+public typealias EquatableCellModelSection = GenericCellModelSection<EquatableCellModel>
 
-    let cells: [CellModel]
-    let headerView: SupplementaryViewModel?
-    let footerView: SupplementaryViewModel?
-    let identifier: String
+public struct GenericCellModelSection<Cell>: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = Cell
 
-    public init(cells: [CellModel] = [], headerView: SupplementaryViewModel? = nil, footerView: SupplementaryViewModel? = nil, identifier: String = "") {
+    public var cells: [Cell]
+    public var headerView: SupplementaryViewModel?
+    public var footerView: SupplementaryViewModel?
+    public let identifier: String
+
+    public init(cells: [Cell] = [], headerView: SupplementaryViewModel? = nil, footerView: SupplementaryViewModel? = nil, identifier: String = "") {
         self.cells = cells
         self.headerView = headerView
         self.footerView = footerView
         self.identifier = identifier
     }
 
-    public convenience required init(arrayLiteral elements: CellModel...) {
+    public init(arrayLiteral elements: Cell...) {
         self.init(cells: elements)
     }
 
-    var isEmpty: Bool {
+    public var isEmpty: Bool {
         return cells.isEmpty
     }
 }
 
+extension GenericCellModelSection: Equatable {
+    public static func == (lhs: GenericCellModelSection<Cell>, rhs: GenericCellModelSection<Cell>) -> Bool {
+        return lhs.identifier == rhs.identifier
+    }
+}

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -1,0 +1,126 @@
+//
+//  CellKitDataSource.swift
+//  CellKit-iOS
+//
+//  Created by Petr Zvoníček on 22.06.18.
+//  Copyright © 2018 FUNTASTY Digital, s.r.o. All rights reserved.
+//
+
+import UIKit
+
+public protocol DataSource {
+    associatedtype Section
+
+    var sections: [Section] { get }
+    var delegate: CellModelDataSourceDelegate? { get }
+    var first: Section? { get }
+
+    subscript(index: Int) -> Section { get }
+}
+
+public class AbstractDataSource: NSObject {
+    public weak var delegate: CellModelDataSourceDelegate?
+
+    public func sectionsCount() -> Int {
+        fatalError("Needs to be overriden")
+    }
+
+    public func cellModels(in section: Int) -> [CellModel] {
+        fatalError("Needs to be overriden")
+    }
+
+    public func header(in section: Int) -> SupplementaryViewModel? {
+        fatalError("Needs to be overriden")
+    }
+
+    public func footer(in section: Int) -> SupplementaryViewModel? {
+        fatalError("Needs to be overriden")
+    }
+
+    public func cellModel(at indexPath: IndexPath) -> CellModel {
+        fatalError("Needs to be overriden")
+    }
+}
+
+extension AbstractDataSource: UITableViewDataSource {
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return sectionsCount()
+    }
+
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return cellModels(in: section).count
+    }
+
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let item = cellModel(at: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier, for: indexPath)
+        item.configure(cell: cell)
+        return cell
+    }
+
+    public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return cellModel(at: indexPath).highlighting
+    }
+
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if let item = header(in: section), let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: item.reuseIdentifier) {
+            item.configure(cell: header)
+            return header
+        }
+        return nil
+    }
+
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return header(in: section)?.height ?? CGFloat.leastNonzeroMagnitude
+    }
+
+    public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        if let item = footer(in: section), let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: item.reuseIdentifier) {
+            item.configure(cell: footer)
+            return footer
+        }
+        return nil
+    }
+
+    public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return footer(in: section)?.height ?? CGFloat.leastNonzeroMagnitude
+    }
+}
+
+
+extension AbstractDataSource: UICollectionViewDataSource {
+    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return sectionsCount()
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return cellModels(in: section).count
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let item = cellModel(at: indexPath)
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: item.reuseIdentifier, for: indexPath)
+        item.configure(cell: cell)
+        return cell
+    }
+}
+
+extension AbstractDataSource: UITableViewDelegate {
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return cellModel(at: indexPath).cellHeight
+    }
+
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let cellModel = cellModel(at: indexPath) as? CellModelSelectable {
+            cellModel.didSelect()
+        }
+
+        delegate?.didSelectCellModel(cellModel(at: indexPath), at: indexPath)
+    }
+}
+
+extension AbstractDataSource: UICollectionViewDelegate {
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        delegate?.didSelectCellModel(cellModel(at: indexPath), at: indexPath)
+    }
+}

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -21,7 +21,7 @@ public protocol DataSource {
 public class AbstractDataSource: NSObject {
     public weak var delegate: CellModelDataSourceDelegate?
 
-    public func sectionsCount() -> Int {
+    public func numberOfSections() -> Int {
         fatalError("Needs to be overriden")
     }
 
@@ -44,7 +44,7 @@ public class AbstractDataSource: NSObject {
 
 extension AbstractDataSource: UITableViewDataSource {
     public func numberOfSections(in tableView: UITableView) -> Int {
-        return sectionsCount()
+        return numberOfSections()
     }
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -90,7 +90,7 @@ extension AbstractDataSource: UITableViewDataSource {
 
 extension AbstractDataSource: UICollectionViewDataSource {
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return sectionsCount()
+        return numberOfSections()
     }
 
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -19,25 +19,28 @@ public protocol DataSource {
 }
 
 public class AbstractDataSource: NSObject {
+
+    internal override init() { }
+
     public weak var delegate: CellModelDataSourceDelegate?
 
-    public func numberOfSections() -> Int {
+    func numberOfSections() -> Int {
         fatalError("Needs to be overriden")
     }
 
-    public func cellModels(in section: Int) -> [CellModel] {
+    func cellModels(in section: Int) -> [CellModel] {
         fatalError("Needs to be overriden")
     }
 
-    public func header(in section: Int) -> SupplementaryViewModel? {
+    func header(in section: Int) -> SupplementaryViewModel? {
         fatalError("Needs to be overriden")
     }
 
-    public func footer(in section: Int) -> SupplementaryViewModel? {
+    func footer(in section: Int) -> SupplementaryViewModel? {
         fatalError("Needs to be overriden")
     }
 
-    public func cellModel(at indexPath: IndexPath) -> CellModel {
+    func cellModel(at indexPath: IndexPath) -> CellModel {
         fatalError("Needs to be overriden")
     }
 }

--- a/Sources/EquatableCellModelDataSource.swift
+++ b/Sources/EquatableCellModelDataSource.swift
@@ -7,3 +7,59 @@
 //
 
 import UIKit
+
+public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
+
+    public var sections: [EquatableCellModelSection] {
+        get {
+            return diffCalculator.sectionedValues.sections
+        }
+        set {
+            diffCalculator.sectionedValues = SectionedValues(newValue.map { ($0, $0.cells.map { $0.asEquatable() }) })
+        }
+    }    
+
+    public var first: EquatableCellModelSection? {
+        return diffCalculator.sectionedValues.sections.first
+    }
+
+    let diffCalculator: AbstractDiffCalculator<EquatableCellModelSection, AnyEquatableCellModel>
+
+    public init(_ tableView: UITableView, sections: [EquatableCellModelSection]) {
+        self.diffCalculator = TableViewDiffCalculator(tableView: tableView)
+        super.init()
+
+        self.sections = sections
+    }
+
+    public init(_ collectionView: UICollectionView, sections: [EquatableCellModelSection]) {
+        self.diffCalculator = CollectionViewDiffCalculator(collectionView: collectionView)
+        super.init()
+
+        self.sections = sections
+    }
+
+    public subscript(index: Int) -> EquatableCellModelSection {
+        return diffCalculator.sectionedValues.sections[index]
+    }
+
+    public override func sectionsCount() -> Int {
+        return self.diffCalculator.numberOfSections()
+    }
+
+    public override func cellModels(in section: Int) -> [CellModel] {
+        return self.diffCalculator.value(forSection: section).cells
+    }
+
+    public override func header(in section: Int) -> SupplementaryViewModel? {
+        return self.diffCalculator.value(forSection: section).headerView
+    }
+
+    public override func footer(in section: Int) -> SupplementaryViewModel? {
+        return self.diffCalculator.value(forSection: section).footerView
+    }
+
+    public override func cellModel(at indexPath: IndexPath) -> CellModel {
+        return self.diffCalculator.value(atIndexPath: indexPath)
+    }
+}

--- a/Sources/EquatableDataSource/EquatableCellModelDataSource.swift
+++ b/Sources/EquatableDataSource/EquatableCellModelDataSource.swift
@@ -44,7 +44,7 @@ public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
         return diffCalculator.value(forSection: index)
     }
 
-    public override func sectionsCount() -> Int {
+    public override func numberOfSections() -> Int {
         return self.diffCalculator.numberOfSections()
     }
 

--- a/Sources/EquatableDataSource/EquatableCellModelDataSource.swift
+++ b/Sources/EquatableDataSource/EquatableCellModelDataSource.swift
@@ -7,12 +7,13 @@
 //
 
 import UIKit
+import Dwifft
 
 public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
 
     public var sections: [EquatableCellModelSection] {
         get {
-            return diffCalculator.sectionedValues.sections
+            return diffCalculator.sectionedValues.sectionsAndValues.map { $0.0 }
         }
         set {
             diffCalculator.sectionedValues = SectionedValues(newValue.map { ($0, $0.cells.map { $0.asEquatable() }) })
@@ -20,7 +21,7 @@ public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
     }    
 
     public var first: EquatableCellModelSection? {
-        return diffCalculator.sectionedValues.sections.first
+        return sections.first
     }
 
     let diffCalculator: AbstractDiffCalculator<EquatableCellModelSection, AnyEquatableCellModel>
@@ -40,7 +41,7 @@ public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
     }
 
     public subscript(index: Int) -> EquatableCellModelSection {
-        return diffCalculator.sectionedValues.sections[index]
+        return diffCalculator.value(forSection: index)
     }
 
     public override func sectionsCount() -> Int {

--- a/Sources/EquatableDataSource/EquatableCellModelDataSource.swift
+++ b/Sources/EquatableDataSource/EquatableCellModelDataSource.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Dwifft
 
-public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
+open class EquatableCellModelDataSource: AbstractDataSource, DataSource {
 
     public var sections: [EquatableCellModelSection] {
         get {
@@ -44,23 +44,23 @@ public class EquatableCellModelDataSource: AbstractDataSource, DataSource {
         return diffCalculator.value(forSection: index)
     }
 
-    public override func numberOfSections() -> Int {
+    override func numberOfSections() -> Int {
         return self.diffCalculator.numberOfSections()
     }
 
-    public override func cellModels(in section: Int) -> [CellModel] {
+    override func cellModels(in section: Int) -> [CellModel] {
         return self.diffCalculator.value(forSection: section).cells
     }
 
-    public override func header(in section: Int) -> SupplementaryViewModel? {
+    override func header(in section: Int) -> SupplementaryViewModel? {
         return self.diffCalculator.value(forSection: section).headerView
     }
 
-    public override func footer(in section: Int) -> SupplementaryViewModel? {
+    override func footer(in section: Int) -> SupplementaryViewModel? {
         return self.diffCalculator.value(forSection: section).footerView
     }
 
-    public override func cellModel(at indexPath: IndexPath) -> CellModel {
+    override func cellModel(at indexPath: IndexPath) -> CellModel {
         return self.diffCalculator.value(atIndexPath: indexPath)
     }
 }


### PR DESCRIPTION
I'm bit unsure about naming of some classes, such as
- `EquatableCellModelDataSource` (sounds too long to me)
- `GenericCellModelSection` (don't like the "Generic", but it's nice to keep CellModelSection for `GenericCellModelSection<CellModel>`)

Also, I used Carthage to manage dependencies in the example project so there is no need to wrap it to CocoaPods workspace, create a Podfile for it etc. And also, it makes it easier to integrate CellKit using Carthage as well. Thus `carthage update` needs to be called to build Dwifft.