### PR TITLE
Fix TableView headers and footers

### DIFF
--- a/CellKit.xcodeproj/project.pbxproj
+++ b/CellKit.xcodeproj/project.pbxproj
@@ -45,9 +45,9 @@
 		D095542720DFE96900BA32F9 /* Dwifft.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D095542520DFE96800BA32F9 /* Dwifft.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DD7502881C68FEDE006590AF /* CellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* CellKit.framework */; };
 		DD7502921C690C7A006590AF /* CellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* CellKit.framework */; };
-		E7AE9F5920EA6E0700830345 /* ReusableCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5820EA6E0700830345 /* ReusableCellModel.swift */; };
-		E7AE9F5A20EA6E0700830345 /* ReusableCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5820EA6E0700830345 /* ReusableCellModel.swift */; };
-		E7AE9F5B20EA6E0700830345 /* ReusableCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5820EA6E0700830345 /* ReusableCellModel.swift */; };
+		E7AE9F5920EA6E0700830345 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5820EA6E0700830345 /* ReusableView.swift */; };
+		E7AE9F5A20EA6E0700830345 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5820EA6E0700830345 /* ReusableView.swift */; };
+		E7AE9F5B20EA6E0700830345 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5820EA6E0700830345 /* ReusableView.swift */; };
 		E7AE9F5F20EA6F8F00830345 /* NibTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E7AE9F5C20EA6F8F00830345 /* NibTableViewCell.xib */; };
 		E7AE9F6120EA6F8F00830345 /* NibTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5D20EA6F8F00830345 /* NibTableViewCell.swift */; };
 		E7BF419E20D7BC5700187490 /* CellConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BF419D20D7BC5700187490 /* CellConfigurable.swift */; };
@@ -130,7 +130,7 @@
 		D095542520DFE96800BA32F9 /* Dwifft.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dwifft.framework; path = Carthage/Build/iOS/Dwifft.framework; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* CellKit-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75028D1C690C7A006590AF /* CellKit-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CellKit-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E7AE9F5820EA6E0700830345 /* ReusableCellModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableCellModel.swift; sourceTree = "<group>"; };
+		E7AE9F5820EA6E0700830345 /* ReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
 		E7AE9F5C20EA6F8F00830345 /* NibTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NibTableViewCell.xib; sourceTree = "<group>"; };
 		E7AE9F5D20EA6F8F00830345 /* NibTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibTableViewCell.swift; sourceTree = "<group>"; };
 		E7BF419D20D7BC5700187490 /* CellConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurable.swift; sourceTree = "<group>"; };
@@ -200,9 +200,9 @@
 			children = (
 				D095542520DFE96800BA32F9 /* Dwifft.framework */,
 				8933C7811EB5B7E0000D00A4 /* Sources */,
+				D02135A520CA609D00EE79D1 /* Example */,
 				8933C7831EB5B7EB000D00A4 /* Tests */,
 				52D6D99C1BEFF38C002C0205 /* Configs */,
-				D02135A520CA609D00EE79D1 /* Example */,
 				52D6D97D1BEFF229002C0205 /* Products */,
 				D02135CB20CA7ABF00EE79D1 /* Frameworks */,
 			);
@@ -238,7 +238,7 @@
 				D02135B620CA6E6D00EE79D1 /* CellModel.swift */,
 				D02135BB20CA6EA600EE79D1 /* CellConvertible.swift */,
 				E7BF419D20D7BC5700187490 /* CellConfigurable.swift */,
-				E7AE9F5820EA6E0700830345 /* ReusableCellModel.swift */,
+				E7AE9F5820EA6E0700830345 /* ReusableView.swift */,
 				D095541820DD335900BA32F9 /* DataSource.swift */,
 				D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */,
 				D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */,
@@ -259,6 +259,7 @@
 		D02135A520CA609D00EE79D1 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				D08037402101DD3300FE8C2A /* Headers */,
 				D082B7CB20CA9F8600B5E7C8 /* Cells */,
 				D02135A620CA609D00EE79D1 /* AppDelegate.swift */,
 				D02135A820CA609D00EE79D1 /* ViewController.swift */,
@@ -597,7 +598,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7AE9F5920EA6E0700830345 /* ReusableCellModel.swift in Sources */,
+				E7AE9F5920EA6E0700830345 /* ReusableView.swift in Sources */,
 				D02135BC20CA6EA600EE79D1 /* CellConvertible.swift in Sources */,
 				D082B7D320CACA8300B5E7C8 /* EquatableCellModelDataSource.swift in Sources */,
 				E7BF419E20D7BC5700187490 /* CellConfigurable.swift in Sources */,
@@ -624,7 +625,7 @@
 				D02135C820CA742B00EE79D1 /* CellModelSelectable.swift in Sources */,
 				D082B7D020CACA8100B5E7C8 /* EquatableCellModelDataSource.swift in Sources */,
 				D082B7E920D3A73C00B5E7C8 /* CellModelSection.swift in Sources */,
-				E7AE9F5B20EA6E0700830345 /* ReusableCellModel.swift in Sources */,
+				E7AE9F5B20EA6E0700830345 /* ReusableView.swift in Sources */,
 				D02135BD20CA6EAA00EE79D1 /* CellConvertible.swift in Sources */,
 				D082B7EB20D3A75300B5E7C8 /* CellModelDataSource.swift in Sources */,
 				D02135B820CA6E7100EE79D1 /* CellModel.swift in Sources */,
@@ -638,7 +639,7 @@
 				D02135C620CA742B00EE79D1 /* CellModelSelectable.swift in Sources */,
 				D082B7D220CACA8200B5E7C8 /* EquatableCellModelDataSource.swift in Sources */,
 				D082B7E720D3A73B00B5E7C8 /* CellModelSection.swift in Sources */,
-				E7AE9F5A20EA6E0700830345 /* ReusableCellModel.swift in Sources */,
+				E7AE9F5A20EA6E0700830345 /* ReusableView.swift in Sources */,
 				D02135BF20CA6EAA00EE79D1 /* CellConvertible.swift in Sources */,
 				D082B7EA20D3A75200B5E7C8 /* CellModelDataSource.swift in Sources */,
 				D02135BA20CA6E7100EE79D1 /* CellModel.swift in Sources */,

--- a/CellKit.xcodeproj/project.pbxproj
+++ b/CellKit.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		D02135C520CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
 		D02135C620CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
 		D02135C820CA742B00EE79D1 /* CellModelSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */; };
+		D08037442101DD3C00FE8C2A /* PhonesHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08037412101DD3B00FE8C2A /* PhonesHeaderModel.swift */; };
+		D08037452101DD3C00FE8C2A /* PhonesHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08037422101DD3B00FE8C2A /* PhonesHeader.xib */; };
+		D08037462101DD3C00FE8C2A /* PhonesHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08037432101DD3C00FE8C2A /* PhonesHeader.swift */; };
 		D082B7CA20CA985100B5E7C8 /* DeviceiOSCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7C920CA985100B5E7C8 /* DeviceiOSCellModel.swift */; };
 		D082B7CD20CA9F9400B5E7C8 /* DeviceiOSCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CC20CA9F9400B5E7C8 /* DeviceiOSCell.swift */; };
 		D082B7D020CACA8100B5E7C8 /* EquatableCellModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */; };
@@ -118,6 +121,9 @@
 		D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellModelDataSource.swift; sourceTree = "<group>"; };
 		D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellModelSection.swift; sourceTree = "<group>"; };
 		D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellModelSelectable.swift; sourceTree = "<group>"; };
+		D08037412101DD3B00FE8C2A /* PhonesHeaderModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhonesHeaderModel.swift; sourceTree = "<group>"; };
+		D08037422101DD3B00FE8C2A /* PhonesHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PhonesHeader.xib; sourceTree = "<group>"; };
+		D08037432101DD3C00FE8C2A /* PhonesHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhonesHeader.swift; sourceTree = "<group>"; };
 		D082B7C920CA985100B5E7C8 /* DeviceiOSCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceiOSCellModel.swift; sourceTree = "<group>"; };
 		D082B7CC20CA9F9400B5E7C8 /* DeviceiOSCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceiOSCell.swift; sourceTree = "<group>"; };
 		D082B7CE20CACA4500B5E7C8 /* EquatableCellModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableCellModelDataSource.swift; sourceTree = "<group>"; };
@@ -279,6 +285,16 @@
 				D095541A20DFDA7F00BA32F9 /* Dwifft.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D08037402101DD3300FE8C2A /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				D08037432101DD3C00FE8C2A /* PhonesHeader.swift */,
+				D08037422101DD3B00FE8C2A /* PhonesHeader.xib */,
+				D08037412101DD3B00FE8C2A /* PhonesHeaderModel.swift */,
+			);
+			path = Headers;
 			sourceTree = "<group>";
 		};
 		D082B7CB20CA9F8600B5E7C8 /* Cells */ = {
@@ -574,6 +590,7 @@
 				E7AE9F5F20EA6F8F00830345 /* NibTableViewCell.xib in Resources */,
 				D02135AE20CA609F00EE79D1 /* Assets.xcassets in Resources */,
 				D02135AC20CA609D00EE79D1 /* Main.storyboard in Resources */,
+				D08037452101DD3C00FE8C2A /* PhonesHeader.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -651,8 +668,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				D02135A920CA609D00EE79D1 /* ViewController.swift in Sources */,
+				D08037462101DD3C00FE8C2A /* PhonesHeader.swift in Sources */,
 				D082B7CD20CA9F9400B5E7C8 /* DeviceiOSCell.swift in Sources */,
 				D095541520DD1D4D00BA32F9 /* DeviceAndroidCell.swift in Sources */,
+				D08037442101DD3C00FE8C2A /* PhonesHeaderModel.swift in Sources */,
 				D082B7CA20CA985100B5E7C8 /* DeviceiOSCellModel.swift in Sources */,
 				E7AE9F6120EA6F8F00830345 /* NibTableViewCell.swift in Sources */,
 				D02135A720CA609D00EE79D1 /* AppDelegate.swift in Sources */,

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -41,6 +40,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/Example/Cells/DeviceAndroidCellModel.swift
+++ b/Example/Cells/DeviceAndroidCellModel.swift
@@ -9,16 +9,12 @@
 import UIKit
 import CellKit
 
-struct DeviceAndroidCellModel: Equatable {
-    let name: String
-}
-
-extension DeviceAndroidCellModel: CellConvertible, EquatableCellModel {
+struct DeviceAndroidCellModel: CellConvertible, EquatableCellModel, Equatable {
     typealias Cell = DeviceAndroidCell
 
-    var cellHeight: CGFloat {
-        return 60.0
-    }
+    let name: String
+    let cellHeight: CGFloat = 60.0
+    let registersLazily: Bool = false
 }
 
 extension DeviceAndroidCellModel: CellModelSelectable {

--- a/Example/Cells/DeviceiOSCellModel.swift
+++ b/Example/Cells/DeviceiOSCellModel.swift
@@ -9,16 +9,12 @@
 import UIKit
 import CellKit
 
-struct DeviceiOSCellModel: Equatable {
-    let name: String
-}
-
-extension DeviceiOSCellModel: CellConvertible, EquatableCellModel {
+struct DeviceiOSCellModel: CellConvertible, EquatableCellModel, Equatable {
     typealias Cell = DeviceiOSCell
 
-    var cellHeight: CGFloat {
-        return 60.0
-    }
+    let name: String
+    let cellHeight: CGFloat = 60.0
+    let registersLazily: Bool = false
 }
 
 extension DeviceiOSCellModel: CellModelSelectable {

--- a/Example/Cells/NibTableViewCell.swift
+++ b/Example/Cells/NibTableViewCell.swift
@@ -13,10 +13,7 @@ struct NibTableViewCellModel: ReusableCellConvertible, EquatableCellModel, Equat
     typealias Cell = NibTableViewCell
 
     let text: String
-
-    var cellHeight: CGFloat {
-        return 170.0
-    }
+    let cellHeight: CGFloat  = 170.0
 }
 
 final class NibTableViewCell: UITableViewCell, CellConfigurable {

--- a/Example/Headers/PhonesHeader.swift
+++ b/Example/Headers/PhonesHeader.swift
@@ -1,0 +1,20 @@
+//
+//  PhonesHeader.swift
+//  SmallAlarmClient
+//
+//  Created by Adam Leitgeb on 23/04/2018.
+//  Copyright © 2018 Adam Leitgeb. All rights reserved.
+//
+
+import UIKit
+import CellKit
+
+class PhonesHeader: UITableViewHeaderFooterView {
+    @IBOutlet private weak var titleLabel: UILabel!
+}
+
+extension PhonesHeader: CellConfigurable {
+    func configure(with model: PhonesHeaderModel) {
+        titleLabel.text = model.title
+    }
+}

--- a/Example/Headers/PhonesHeader.xib
+++ b/Example/Headers/PhonesHeader.xib
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="PhonesHeader" customModule="Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Ei-pz-vOg">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                    <color key="backgroundColor" red="0.99215686274509807" green="0.99215686274509807" blue="0.99215686274509807" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </view>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hCe-U3-FBJ">
+                    <rect key="frame" x="20" y="0.0" width="335" height="50"/>
+                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                    <color key="textColor" red="0.13725490196078433" green="0.12156862745098039" blue="0.12549019607843137" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="9Ei-pz-vOg" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="5Pq-EN-0L1"/>
+                <constraint firstItem="9Ei-pz-vOg" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="8pf-g0-Jzr"/>
+                <constraint firstItem="9Ei-pz-vOg" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="9Vi-cQ-zih"/>
+                <constraint firstItem="hCe-U3-FBJ" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="Bk8-Ub-boc"/>
+                <constraint firstItem="9Ei-pz-vOg" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="KfC-QJ-bG6"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="hCe-U3-FBJ" secondAttribute="trailing" constant="20" id="Wbh-z2-XpV"/>
+                <constraint firstItem="hCe-U3-FBJ" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="lIv-Ms-AhV"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="hCe-U3-FBJ" secondAttribute="bottom" id="yVq-1q-wbg"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="titleLabel" destination="hCe-U3-FBJ" id="k25-3Y-92K"/>
+            </connections>
+            <point key="canvasLocation" x="33.5" y="-237"/>
+        </view>
+    </objects>
+</document>

--- a/Example/Headers/PhonesHeaderModel.swift
+++ b/Example/Headers/PhonesHeaderModel.swift
@@ -1,0 +1,23 @@
+//
+//  TableViewHeaderViewModel.swift
+//  SmallAlarmClient
+//
+//  Created by Adam Leitgeb on 23/04/2018.
+//  Copyright © 2018 Adam Leitgeb. All rights reserved.
+//
+
+import Foundation
+import UIKit.UIView
+import CellKit
+
+struct PhonesHeaderModel {
+    let title: String
+}
+
+extension PhonesHeaderModel: SupplementaryViewModel, CellConvertible {
+    typealias Cell = PhonesHeader
+
+    var height: CGFloat {
+        return 50
+    }
+}

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -22,7 +22,9 @@ class ViewController: UIViewController {
         let iPhoneCellModels: [EquatableCellModel] = iPhones.prefix(5).map { DeviceiOSCellModel(name: $0) }
         let androidCellModels: [EquatableCellModel] = androids.prefix(5).map { DeviceAndroidCellModel(name: $0) }
         let cellModels = iPhoneCellModels + androidCellModels
-        return EquatableCellModelSection(cells: cellModels, identifier: "Section 1")
+        let header = PhonesHeaderModel(title: "Cell Phones")
+
+        return EquatableCellModelSection(cells: cellModels, headerView: header, identifier: "Section 1")
     }
 
     private var welcomeSection: EquatableCellModelSection {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "CellKit",
-            targets: ["CellKit"]),
+            targets: ["CellKit"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -23,6 +23,6 @@ let package = Package(
             dependencies: []),
         .testTarget(
             name: "CellKitTests",
-            dependencies: ["CellKit"]),
+            dependencies: ["CellKit"])
     ]
 )

--- a/Sources/CellConvertible.swift
+++ b/Sources/CellConvertible.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 FUNTASTY Digital, s.r.o. All rights reserved.
 //
 
-public typealias ReusableCellConvertible = CellConvertible & ReusableCellModel
+public typealias ReusableCellConvertible = CellConvertible & ReusableView
 
 public protocol CellConvertible: CellModel {
     associatedtype Cell: CellConfigurable

--- a/Sources/CellConvertible.swift
+++ b/Sources/CellConvertible.swift
@@ -8,7 +8,7 @@
 
 public typealias ReusableCellConvertible = CellConvertible & ReusableView
 
-public protocol CellConvertible: CellModel {
+public protocol CellConvertible {
     associatedtype Cell: CellConfigurable
 }
 

--- a/Sources/CellModel.swift
+++ b/Sources/CellModel.swift
@@ -55,6 +55,8 @@ public extension CellModel {
 
 public protocol SupplementaryViewModel: ReusableView {
     var height: CGFloat { get }
+    
+    func configure(cell: AnyObject)
 }
 
 public struct AnyEquatableCellModel: EquatableCellModel {

--- a/Sources/CellModel.swift
+++ b/Sources/CellModel.swift
@@ -50,7 +50,7 @@ public extension CellModel {
 
 public protocol SupplementaryViewModel: ReusableView {
     var height: CGFloat { get }
-    
+
     func configure(cell: AnyObject)
 }
 
@@ -59,7 +59,6 @@ public struct AnyEquatableCellModel: EquatableCellModel {
 
     // MARK: - Reusable view properties
 
-    
     public var registersLazily: Bool {
         return cellModel.registersLazily
     }
@@ -89,7 +88,7 @@ public struct AnyEquatableCellModel: EquatableCellModel {
     public var cellHeight: CGFloat {
         return cellModel.cellHeight
     }
-    
+
     public var highlighting: Bool {
         return cellModel.highlighting
     }

--- a/Sources/CellModel.swift
+++ b/Sources/CellModel.swift
@@ -14,7 +14,6 @@ public protocol CellModel: ReusableView {
     var cellHeight: CGFloat { get }
     var highlighting: Bool { get }
     var separatorIsHidden: Bool { get }
-    var hashableElement: AnyHashable? { get }
 
     func configure(cell: AnyObject)
 }
@@ -46,10 +45,6 @@ public extension CellModel {
 
     var separatorIsHidden: Bool {
         return false
-    }
-
-    var hashableElement: AnyHashable? {
-        return nil
     }
 }
 
@@ -94,14 +89,13 @@ public struct AnyEquatableCellModel: EquatableCellModel {
     public var cellHeight: CGFloat {
         return cellModel.cellHeight
     }
+    
     public var highlighting: Bool {
         return cellModel.highlighting
     }
+
     public var separatorIsHidden: Bool {
         return cellModel.separatorIsHidden
-    }
-    public var hashableElement: AnyHashable? {
-        return cellModel.hashableElement
     }
 
     init(_ cellModel: EquatableCellModel) {

--- a/Sources/CellModel.swift
+++ b/Sources/CellModel.swift
@@ -57,7 +57,7 @@ public protocol SupplementaryViewModel: ReusableView {
 public struct AnyEquatableCellModel: EquatableCellModel {
     public var cellModel: EquatableCellModel
 
-    // MARK: - Reusable view
+    // MARK: - Reusable view properties
 
     
     public var registersLazily: Bool {
@@ -84,7 +84,7 @@ public struct AnyEquatableCellModel: EquatableCellModel {
         return cellModel.reuseIdentifier
     }
 
-    // MARK: -
+    // MARK: - Cell model properties
 
     public var cellHeight: CGFloat {
         return cellModel.cellHeight

--- a/Sources/CellModel.swift
+++ b/Sources/CellModel.swift
@@ -7,11 +7,10 @@
 //
 
 import struct UIKit.CGFloat
+import class Foundation.Bundle
+import class UIKit.UINib
 
-public protocol CellModel {
-    var cellClass: AnyClass { get }
-    var reuseIdentifier: String { get }
-
+public protocol CellModel: ReusableView {
     var cellHeight: CGFloat { get }
     var highlighting: Bool { get }
     var separatorIsHidden: Bool { get }
@@ -54,19 +53,41 @@ public extension CellModel {
     }
 }
 
-public protocol SupplementaryViewModel: CellModel {
+public protocol SupplementaryViewModel: ReusableView {
     var height: CGFloat { get }
 }
 
 public struct AnyEquatableCellModel: EquatableCellModel {
     public var cellModel: EquatableCellModel
 
+    // MARK: - Reusable view
+
+    
+    public var registersLazily: Bool {
+        return cellModel.registersLazily
+    }
+
+    public var usesNib: Bool {
+        return cellModel.usesNib
+    }
+
+    public var bundle: Bundle {
+        return cellModel.bundle
+    }
+
+    public var nib: UINib? {
+        return cellModel.nib
+    }
+
     public var cellClass: AnyClass {
         return cellModel.cellClass
     }
+
     public var reuseIdentifier: String {
         return cellModel.reuseIdentifier
     }
+
+    // MARK: -
 
     public var cellHeight: CGFloat {
         return cellModel.cellHeight

--- a/Sources/CellModelSelectable.swift
+++ b/Sources/CellModelSelectable.swift
@@ -9,4 +9,3 @@
 public protocol CellModelSelectable {
     func didSelect()
 }
-

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -143,7 +143,6 @@ extension AbstractDataSource: UITableViewDataSource {
     }
 }
 
-
 extension AbstractDataSource: UICollectionViewDataSource {
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return numberOfSections()

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -61,7 +61,7 @@ open class AbstractDataSource: NSObject {
     }
 
     private func registerLazily(cellModel: CellModel, to collectionView: UICollectionView) {
-        guard registersCellsLazily, !registeredCellReuseIdentifiers.contains(cellModel.reuseIdentifier) else {
+        guard registersCellsLazily, cellModel.registersLazily, !registeredCellReuseIdentifiers.contains(cellModel.reuseIdentifier) else {
             return
         }
 
@@ -75,12 +75,12 @@ open class AbstractDataSource: NSObject {
     }
 
     private func registerLazily(headerFooter: SupplementaryViewModel, to tableView: UITableView) {
-        guard registersCellsLazily, !registeredHeaderFooterReuseIdentifiers.contains(headerFooter.reuseIdentifier) else {
+        guard registersCellsLazily, headerFooter.registersLazily, !registeredHeaderFooterReuseIdentifiers.contains(headerFooter.reuseIdentifier) else {
             return
         }
 
         if let nib = headerFooter.nib {
-            tableView.register(nib, forCellReuseIdentifier: headerFooter.reuseIdentifier)
+            tableView.register(nib, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)
         } else {
             tableView.register(headerFooter.cellClass, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)
         }
@@ -121,7 +121,10 @@ extension AbstractDataSource: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return view(for: header(in: section), in: tableView)
+        let model = header(in: section)
+        let headerView = view(for: model, in: tableView)
+        headerView.flatMap { model?.configure(cell: $0) }
+        return headerView
     }
 
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -129,7 +132,10 @@ extension AbstractDataSource: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return view(for: footer(in: section), in: tableView)
+        let model = header(in: section)
+        let footerView = view(for: model, in: tableView)
+        footerView.flatMap { model?.configure(cell: $0) }
+        return footerView
     }
 
     public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -47,12 +47,8 @@ open class AbstractDataSource: NSObject {
         fatalError("Needs to be overriden")
     }
 
-    private func reusable(cellModel: CellModel) -> ReusableCellModel? {
-        return cellModel as? ReusableCellModel ?? (cellModel as? AnyEquatableCellModel)?.cellModel as? ReusableCellModel
-    }
-
     private func registerLazily(cellModel: CellModel, to tableView: UITableView) {
-        guard registersCellsLazily, let cellModel = reusable(cellModel: cellModel), !registeredCellReuseIdentifiers.contains(cellModel.reuseIdentifier) else {
+        guard registersCellsLazily, cellModel.registersLazily, !registeredCellReuseIdentifiers.contains(cellModel.reuseIdentifier) else {
             return
         }
 
@@ -65,7 +61,7 @@ open class AbstractDataSource: NSObject {
     }
 
     private func registerLazily(cellModel: CellModel, to collectionView: UICollectionView) {
-        guard registersCellsLazily, let cellModel = reusable(cellModel: cellModel), !registeredCellReuseIdentifiers.contains(cellModel.reuseIdentifier) else {
+        guard registersCellsLazily, !registeredCellReuseIdentifiers.contains(cellModel.reuseIdentifier) else {
             return
         }
 
@@ -79,14 +75,14 @@ open class AbstractDataSource: NSObject {
     }
 
     private func registerLazily(headerFooter: SupplementaryViewModel, to tableView: UITableView) {
-        guard registersCellsLazily, let cellModel = reusable(cellModel: headerFooter), !registeredHeaderFooterReuseIdentifiers.contains(headerFooter.reuseIdentifier) else {
+        guard registersCellsLazily, !registeredHeaderFooterReuseIdentifiers.contains(headerFooter.reuseIdentifier) else {
             return
         }
 
-        if let nib = cellModel.nib {
-            tableView.register(nib, forCellReuseIdentifier: cellModel.reuseIdentifier)
+        if let nib = headerFooter.nib {
+            tableView.register(nib, forCellReuseIdentifier: headerFooter.reuseIdentifier)
         } else {
-            tableView.register(cellModel.cellClass, forHeaderFooterViewReuseIdentifier: cellModel.reuseIdentifier)
+            tableView.register(headerFooter.cellClass, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)
         }
         registeredHeaderFooterReuseIdentifiers.insert(headerFooter.reuseIdentifier)
     }

--- a/Sources/ReusableView.swift
+++ b/Sources/ReusableView.swift
@@ -9,13 +9,21 @@
 import class Foundation.Bundle
 import class UIKit.UINib
 
-public protocol ReusableCellModel: CellModel {
+public protocol ReusableView {
+    var registersLazily: Bool { get }
     var usesNib: Bool { get }
     var bundle: Bundle { get }
     var nib: UINib? { get }
+
+    var cellClass: AnyClass { get }
+    var reuseIdentifier: String { get }
 }
 
-public extension ReusableCellModel {
+public extension ReusableView {
+    var registersLazily: Bool {
+        return true
+    }
+
     var usesNib: Bool {
         return true
     }

--- a/Tests/CellKitTests/CellKitTests.swift
+++ b/Tests/CellKitTests/CellKitTests.swift
@@ -16,8 +16,8 @@ class CellKitTests: XCTestCase {
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         //// XCTAssertEqual(CellKit().text, "Hello, World!")
     }
-    
+
     static var allTests = [
-        ("testExample", testExample),
+        ("testExample", testExample)
     ]
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import CellKitTests
 
 XCTMain([
-    testCase(CellKitTests.allTests),
+    testCase(CellKitTests.allTests)
 ])


### PR DESCRIPTION
TableView headers and footers were broken in the latest version, this PR fixes that. Also a header is added to example project.

Major changes:

- Rename ReusableCellModel to ReusableView, make ReusableView independent on CellModel
- CellModel and SupplementaryViewModel now adopts ReusableView 
- CellConvertible is independent on CellModel

Model of header is meant to implement SupplementaryViewModel and CellConvertible. `CellConvertible` name is now not very descriptive, but this PR leave it as it is for now.