### PR TITLE
Collection view supplementary views

### DIFF
--- a/CellKit.podspec
+++ b/CellKit.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.social_media_url       = "https://twitter.com/TheFuntasty"
   s.ios.deployment_target  = "8.0"
   s.tvos.deployment_target = "9.0"
-  s.swift_version         = "5.0"
+  s.swift_versions         = ["4.2", "5.0"]
   s.source                 = { git: "https://github.com/thefuntasty/CellKit.git", tag: s.version.to_s }
   s.frameworks             = ["Foundation", "UIKit"]
   s.default_subspec        = "Core"

--- a/CellKit.podspec
+++ b/CellKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CellKit"
-  s.version     = "0.3"
+  s.version     = "0.4"
   s.summary     = "Table View and Collection View data source wrapper"
   s.description = <<-DESC
     Generic abstraction over table/collection data source

--- a/CellKit.podspec
+++ b/CellKit.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.social_media_url       = "https://twitter.com/TheFuntasty"
   s.ios.deployment_target  = "8.0"
   s.tvos.deployment_target = "9.0"
-  s.swift_versions         = ["4.2", "5.0"]
+  s.swift_version         = "5.0"
   s.source                 = { git: "https://github.com/thefuntasty/CellKit.git", tag: s.version.to_s }
   s.frameworks             = ["Foundation", "UIKit"]
   s.default_subspec        = "Core"

--- a/CellKit.podspec
+++ b/CellKit.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   DESC
   s.homepage               = "https://github.com/thefuntasty/CellKit"
   s.license                = { type: "MIT", file: "LICENSE" }
-  s.author                 = { "Petr Zvoníček": "petr.zvonicek@thefuntasty.com" }
+  s.author                 = { "Matěj K. Jirásek": "matej.jirasek@thefuntasty.com", "Petr Zvoníček": "zvonicek@gmail.com" }
   s.social_media_url       = "https://twitter.com/TheFuntasty"
   s.ios.deployment_target  = "8.0"
   s.tvos.deployment_target = "9.0"

--- a/CellKit.xcodeproj/project.pbxproj
+++ b/CellKit.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		E7AE9F6120EA6F8F00830345 /* NibTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE9F5D20EA6F8F00830345 /* NibTableViewCell.swift */; };
 		E7B8C004225CB883003B042C /* CellKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B8C003225CB883003B042C /* CellKitTests.swift */; };
 		E7BF419E20D7BC5700187490 /* CellConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BF419D20D7BC5700187490 /* CellConfigurable.swift */; };
+		E7FC683922835CE90080E326 /* CollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FC683822835CE90080E326 /* CollectionReusableView.swift */; };
+		E7FC683A22835CEC0080E326 /* CollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FC683822835CE90080E326 /* CollectionReusableView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +117,7 @@
 		E7B8C003225CB883003B042C /* CellKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellKitTests.swift; sourceTree = "<group>"; };
 		E7B8C005225CB883003B042C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E7BF419D20D7BC5700187490 /* CellConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurable.swift; sourceTree = "<group>"; };
+		E7FC683822835CE90080E326 /* CollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionReusableView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,6 +201,7 @@
 				D02135C420CA742B00EE79D1 /* CellModelSelectable.swift */,
 				D02135C020CA6EDE00EE79D1 /* CellModelDataSource.swift */,
 				D02135C220CA6FEE00EE79D1 /* CellModelSection.swift */,
+				E7FC683822835CE90080E326 /* CollectionReusableView.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -471,6 +475,7 @@
 				E7AE9F5920EA6E0700830345 /* ReusableView.swift in Sources */,
 				D02135BC20CA6EA600EE79D1 /* CellConvertible.swift in Sources */,
 				D082B7D320CACA8300B5E7C8 /* EquatableCellModelDataSource.swift in Sources */,
+				E7FC683922835CE90080E326 /* CollectionReusableView.swift in Sources */,
 				E7BF419E20D7BC5700187490 /* CellConfigurable.swift in Sources */,
 				D02135C120CA6EDE00EE79D1 /* CellModelDataSource.swift in Sources */,
 				D02135C520CA742B00EE79D1 /* CellModelSelectable.swift in Sources */,
@@ -487,6 +492,7 @@
 				D02135C820CA742B00EE79D1 /* CellModelSelectable.swift in Sources */,
 				D082B7D020CACA8100B5E7C8 /* EquatableCellModelDataSource.swift in Sources */,
 				E7A4E045223122D40097CB6F /* CellConfigurable.swift in Sources */,
+				E7FC683A22835CEC0080E326 /* CollectionReusableView.swift in Sources */,
 				E7A4E046223122E10097CB6F /* DataSource.swift in Sources */,
 				D082B7E920D3A73C00B5E7C8 /* CellModelSection.swift in Sources */,
 				E7AE9F5B20EA6E0700830345 /* ReusableView.swift in Sources */,

--- a/Sources/CellModelDataSource.swift
+++ b/Sources/CellModelDataSource.swift
@@ -18,6 +18,7 @@ open class CellModelDataSource: AbstractDataSource, DataSource {
 
     public override init() {
         self.sections = []
+        super.init()
     }
 
     public init(_ sections: [CellModelSection]) {

--- a/Sources/CellModelDataSource.swift
+++ b/Sources/CellModelDataSource.swift
@@ -16,6 +16,10 @@ open class CellModelDataSource: AbstractDataSource, DataSource {
 
     public var sections: [CellModelSection]
 
+    public override init() {
+        self.sections = []
+    }
+
     public init(_ sections: [CellModelSection]) {
         self.sections = sections
     }

--- a/Sources/CollectionReusableView.swift
+++ b/Sources/CollectionReusableView.swift
@@ -1,0 +1,27 @@
+//
+//  CollectionReusableView.swift
+//  CellKit-iOS
+//
+//  Created by Matěj Kašpar Jirásek on 08/05/2019.
+//  Copyright © 2019 FUNTASTY Digital, s.r.o. All rights reserved.
+//
+
+import class UIKit.UICollectionReusableView
+
+public final class CollectionReusableView: UICollectionReusableView, CellConfigurable {
+    public func configure(with model: CollectionReusableViewModel) {
+    }
+}
+
+public struct CollectionReusableViewModel: SupplementaryViewModel, CellConvertible {
+    public typealias Cell = CollectionReusableView
+
+    public var height: Double {
+        return 0.0
+    }
+
+    public var usesNib: Bool {
+        return false
+    }
+}
+

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -197,7 +197,9 @@ extension AbstractDataSource: UICollectionViewDataSource {
 
     public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let viewModel = supplementaryViewModel(indexPath: indexPath, kind: kind)
-        let reusableView = view(for: viewModel, kind: kind, at: indexPath, in: collectionView) ?? UICollectionReusableView()
+        guard let reusableView = view(for: viewModel, kind: kind, at: indexPath, in: collectionView) ?? view(for: CollectionReusableViewModel(), kind: kind, at: indexPath, in: collectionView) else {
+            fatalError("No supplementary view can be reused")
+        }
         viewModel?.configure(cell: reusableView)
         return reusableView
     }

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -19,8 +19,6 @@ public protocol DataSource {
 
 open class AbstractDataSource: NSObject {
 
-    internal override init() { }
-
     public weak var delegate: CellModelDataSourceDelegate?
 
     public var registersCellsLazily: Bool = true

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -52,7 +52,7 @@ open class AbstractDataSource: NSObject {
             return
         }
 
-        if let nib = cellModel.nib {
+        if cellModel.usesNib, let nib = cellModel.nib {
             tableView.register(nib, forCellReuseIdentifier: cellModel.reuseIdentifier)
         } else {
             tableView.register(cellModel.cellClass, forCellReuseIdentifier: cellModel.reuseIdentifier)
@@ -65,7 +65,7 @@ open class AbstractDataSource: NSObject {
             return
         }
 
-        if let nib = cellModel.nib {
+        if cellModel.usesNib, let nib = cellModel.nib {
             collectionView.register(nib, forCellWithReuseIdentifier: cellModel.reuseIdentifier)
         } else {
             collectionView.register(cellModel.cellClass, forCellWithReuseIdentifier: cellModel.reuseIdentifier)
@@ -78,7 +78,7 @@ open class AbstractDataSource: NSObject {
             return
         }
 
-        if let nib = headerFooter.nib {
+        if headerFooter.usesNib, let nib = headerFooter.nib {
             tableView.register(nib, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)
         } else {
             tableView.register(headerFooter.cellClass, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -25,7 +25,7 @@ open class AbstractDataSource: NSObject {
 
     public var registersCellsLazily: Bool = true
     private var registeredCellReuseIdentifiers: Set<String> = []
-    private var registeredHeaderFooterReuseIdentifiers: Set<String> = []
+    private var registeredSupplementaryViewIdentifiers: Set<String> = []
 
     func numberOfSections() -> Int {
         fatalError("Needs to be overriden")
@@ -74,7 +74,7 @@ open class AbstractDataSource: NSObject {
     }
 
     private func registerLazily(headerFooter: SupplementaryViewModel, to tableView: UITableView) {
-        guard registersCellsLazily, headerFooter.registersLazily, !registeredHeaderFooterReuseIdentifiers.contains(headerFooter.reuseIdentifier) else {
+        guard registersCellsLazily, headerFooter.registersLazily, !registeredSupplementaryViewIdentifiers.contains(headerFooter.reuseIdentifier) else {
             return
         }
 
@@ -83,7 +83,7 @@ open class AbstractDataSource: NSObject {
         } else {
             tableView.register(headerFooter.cellClass, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)
         }
-        registeredHeaderFooterReuseIdentifiers.insert(headerFooter.reuseIdentifier)
+        registeredSupplementaryViewIdentifiers.insert(headerFooter.reuseIdentifier)
     }
 
     private func view(for headerFooter: SupplementaryViewModel?, in tableView: UITableView) -> UIView? {

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -19,6 +19,10 @@ public protocol DataSource {
 
 open class AbstractDataSource: NSObject {
 
+    internal override init() {
+        super.init()
+    }
+
     public weak var delegate: CellModelDataSourceDelegate?
 
     public var registersCellsLazily: Bool = true

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -217,7 +217,7 @@ extension AbstractDataSource: UITableViewDelegate {
     }
 }
 
-extension AbstractDataSource: UICollectionViewDelegate {
+extension AbstractDataSource: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         delegate?.didSelectCellModel(cellModel(at: indexPath), at: indexPath)
     }


### PR DESCRIPTION
Implements #25.

> Currently headers and footers are supported only for table views, even though sections contain them for use in collections too.
> 
> Required changes:
> 
> - Update reuse identifier storage for lazy registration.
> - Implement view for supplementary kind method in abstract data source.
> 
> Next step would be updating the collection reusable view template.