### PR TITLE
Isolate the UIKit-facing API to the main actor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "CellKit",
-    platforms: [.iOS(.v9), .tvOS(.v9)],
+    platforms: [.iOS(.v13), .tvOS(.v13)],
     products: [
         .library(
             name: "CellKit",

--- a/Sources/CellKit/CellConfigurable.swift
+++ b/Sources/CellKit/CellConfigurable.swift
@@ -1,3 +1,4 @@
+@MainActor
 public protocol CellConfigurable: AnyObject {
     associatedtype Model
     func configure(with model: Model)

--- a/Sources/CellKit/CellConvertible.swift
+++ b/Sources/CellKit/CellConvertible.swift
@@ -2,6 +2,7 @@
 //  CellConvertible.swift
 public typealias ReusableCellConvertible = CellConvertible & ReusableView
 
+@MainActor
 public protocol CellConvertible {
     associatedtype Cell: CellConfigurable
 }

--- a/Sources/CellKit/CellModel.swift
+++ b/Sources/CellKit/CellModel.swift
@@ -1,3 +1,4 @@
+@MainActor
 public protocol CellModel: ReusableView {
     var cellHeight: Double { get }
     var highlighting: Bool { get }
@@ -20,6 +21,7 @@ public extension CellModel {
     }
 }
 
+@MainActor
 public protocol SupplementaryViewModel: ReusableView {
     var height: Double { get }
 

--- a/Sources/CellKit/CellModelDataSource.swift
+++ b/Sources/CellKit/CellModelDataSource.swift
@@ -1,9 +1,11 @@
 import struct Foundation.IndexPath
 
+@MainActor
 public protocol CellModelDataSourceDelegate: AnyObject {
     func didSelectCellModel(_ cellModel: CellModel, at indexPath: IndexPath)
 }
 
+@MainActor
 open class CellModelDataSource: AbstractDataSource, DataSource {
 
     public var sections: [CellModelSection]

--- a/Sources/CellKit/CellModelSelectable.swift
+++ b/Sources/CellKit/CellModelSelectable.swift
@@ -1,3 +1,4 @@
+@MainActor
 public protocol CellModelSelectable {
     func didSelect()
 }

--- a/Sources/CellKit/DataSource.swift
+++ b/Sources/CellKit/DataSource.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 public protocol DataSource {
     associatedtype Section
 
@@ -9,6 +10,7 @@ public protocol DataSource {
     subscript(index: Int) -> Section { get }
 }
 
+@MainActor
 open class AbstractDataSource: NSObject {
 
     public weak var delegate: CellModelDataSourceDelegate?

--- a/Sources/CellKit/DiffableDataSources/CollectionSupplementaryViewModel.swift
+++ b/Sources/CellKit/DiffableDataSources/CollectionSupplementaryViewModel.swift
@@ -1,4 +1,5 @@
 @available(iOS 13.0, tvOS 13.0, *)
+@MainActor
 public protocol CollectionSupplementaryViewModel: ReusableView {
     var kind: SupplementaryElementKind { get }
 

--- a/Sources/CellKit/DiffableDataSources/LazyCellProvider.swift
+++ b/Sources/CellKit/DiffableDataSources/LazyCellProvider.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 @available(iOS 13.0, tvOS 13.0, *)
+@MainActor
 public final class LazyCellProvider {
     private var registeredIdentifiers: Set<String>
 

--- a/Sources/CellKit/DiffableDataSources/LazySupplementaryViewProvider.swift
+++ b/Sources/CellKit/DiffableDataSources/LazySupplementaryViewProvider.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 @available(iOS 13.0, tvOS 13.0, *)
+@MainActor
 public final class LazySupplementaryViewProvider {
 
     private var registeredIdentifiers: [String: Set<String>]

--- a/Sources/CellKit/ReusableView.swift
+++ b/Sources/CellKit/ReusableView.swift
@@ -1,6 +1,7 @@
 import class Foundation.Bundle
 import class UIKit.UINib
 
+@MainActor
 public protocol ReusableView {
     var registersLazily: Bool { get }
     var usesNib: Bool { get }

--- a/Sources/DiffableCellKit/DifferentiableCellModel.swift
+++ b/Sources/DiffableCellKit/DifferentiableCellModel.swift
@@ -4,6 +4,7 @@ import CellKit
 #endif
 
 /// Support for determining whether cell model belongs to a certain cell, whether cell should be inserted, removed, updated or moved.
+@MainActor
 public protocol DifferentiableCellModel: CellModel {
 
     /// Identifier of a cell model inside it's own domain determined by reusable identifier. Assuming model is already presented inside a view, changing of this value will result in it's removal and insertion into the view.
@@ -31,14 +32,21 @@ extension DifferentiableCellModel where Self: Equatable {
 
 struct DifferentiableCellModelWrapper {
     let cellModel: DifferentiableCellModel
+    let differenceIdentifier: String
+
+    @MainActor
+    init(cellModel: DifferentiableCellModel) {
+        self.cellModel = cellModel
+        self.differenceIdentifier = "\(cellModel.reuseIdentifier)<.>\(cellModel.domainIdentifier)"
+    }
 }
 
 extension DifferentiableCellModelWrapper: Equatable, Differentiable {
     static func == (lhs: DifferentiableCellModelWrapper, rhs: DifferentiableCellModelWrapper) -> Bool {
-        lhs.cellModel.hasEqualContent(with: rhs.cellModel)
-    }
-
-    var differenceIdentifier: String {
-        "\(cellModel.reuseIdentifier)<.>\(cellModel.domainIdentifier)"
+        // DifferenceKit requires a nonisolated `==`, but wrappers are only ever created and
+        // diffed by `DifferentiableCellModelDataSource`, which is main actor-isolated.
+        MainActor.assumeIsolated {
+            lhs.cellModel.hasEqualContent(with: rhs.cellModel)
+        }
     }
 }

--- a/Sources/DiffableCellKit/DifferentiableCellModelDataSource.swift
+++ b/Sources/DiffableCellKit/DifferentiableCellModelDataSource.swift
@@ -4,6 +4,7 @@ import UIKit
 import CellKit
 #endif
 
+@MainActor
 open class DifferentiableCellModelDataSource: AbstractDataSource, DataSource {
 
     private enum Container {


### PR DESCRIPTION
## Motivation

CellKit is a UITableView/UICollectionView data source layer — every one of its protocols is only ever exercised on the main thread. But the protocols are declared nonisolated, so under Swift 6 every consumer conformance reports:

```
warning: conformance of 'FooCellModel' to protocol 'CellConvertible' crosses into
main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode
```

In an app I migrated to Swift 6 this accounted for **61 of 498 warnings** — the second largest group. The only consumer-side workaround is to annotate every single conformance:

```swift
extension FooCellModel: CellModel, @MainActor ReusableCellConvertible {
```

which had to be repeated 45 times, plus a `@preconcurrency import CellKit` where a cell model is built off the main thread.

## Change

`@MainActor` on the API that touches UIKit:

- **CellKit** — `ReusableView`, `CellConfigurable`, `CellModel`, `SupplementaryViewModel`, `CellConvertible`, `CellModelSelectable`, `CellModelDataSourceDelegate`, `DataSource`, `CollectionSupplementaryViewModel`, `AbstractDataSource`, `CellModelDataSource`, `LazyCellProvider`, `LazySupplementaryViewProvider`
- **DiffableCellKit** — `DifferentiableCellModel`, `DifferentiableCellModelDataSource`

`DifferentiableCellModelWrapper` needed a small rework: DifferenceKit's `Differentiable`/`Equatable` requirements are nonisolated, so `differenceIdentifier` is now computed once in a `@MainActor init` and stored, and `==` uses `MainActor.assumeIsolated`. Wrappers are only ever created and diffed by `DifferentiableCellModelDataSource`, which is now main actor-isolated, so the assumption holds.

`MainActor.assumeIsolated` requires iOS 13, so `Package.swift` platforms go from `.v9` to `.v13`. `DiffableCellKit` already required iOS 13 throughout, and current SPM toolchains no longer accept iOS 9 anyway.

## This is source-breaking

Any conformance that is *not* main actor-isolated will stop compiling. In practice these types are all cells, cell models and data sources, so this should be a no-op for real consumers — but it is a breaking change and probably warrants a minor version bump.

## Verification

`xcodebuild build` passes for both the `CellKit` and `DiffableCellKit` schemes on `generic/platform=iOS`. SwiftLint reports the same 9 pre-existing violations as `main` — none added.

Building `CellKit` with `SWIFT_STRICT_CONCURRENCY=complete` succeeds; two warnings remain in `SupplementaryElementKind`, which reads `UICollectionView.elementKindSectionHeader`/`Footer` from a nonisolated `RawRepresentable` conformance. I left it alone because marking the enum `@MainActor` would break `RawRepresentable`, and the values are immutable strings. Happy to address it separately if you'd prefer.

I could not run the app-side end-to-end check (the consumer pins the released tag), so I have not empirically confirmed that all 45 `@MainActor` annotations become removable — though that is what the change is for.